### PR TITLE
Fix tag serialization (fixes #1)

### DIFF
--- a/app/models/bookmark.js
+++ b/app/models/bookmark.js
@@ -32,9 +32,14 @@ var Bookmark = Ember.Object.extend({
       serialized.createdAt = createdAt;
     }
 
-    if (tags.length > 0) {
-      serialized.tags = tags.split(',').map($.trim);
+    if (tags && tags.length > 0) {
+      if ((typeof tags) === 'string') {
+        serialized.tags = tags.split(',').map($.trim);
+      } else {
+        serialized.tags = tags;
+      }
     }
+
     return serialized;
   }.property()
 


### PR DESCRIPTION
This fixes two exceptions:
- "Object [object Array] has no method 'split'" when editing a bookmark without changing tags
- "Cannot read property 'length' of undefined" when giving no tags at all
