### PR TITLE
Add tests for bookmark form autofocus

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
 machine:
   node:
-    version: 4.5.0
+    version: 6.11.0
 dependencies:
   override:
     - npm config set spin false
     - npm install phantomjs-prebuilt
     - node_modules/phantomjs-prebuilt/bin/phantomjs --version
-    - npm install --dev
+    - npm install

--- a/tests/integration/components/bookmark-form/component-test.js
+++ b/tests/integration/components/bookmark-form/component-test.js
@@ -10,7 +10,7 @@ test('it sets focus on the title field when empty', function(assert) {
   this.render(hbs`{{bookmark-form bookmark=bookmark}}`);
 
   assert.equal(this.$('input#title').val(), '');
-  assert.equal(this.$('input#title').is(":focus"), true);
+  assert.equal(document.activeElement.id, 'title');
 });
 
 test('does not set focus on the title field when filled', function(assert) {
@@ -19,5 +19,5 @@ test('does not set focus on the title field when filled', function(assert) {
 
   assert.equal(this.get('bookmark.title'), 'foo bar');
   assert.equal(this.$('input#title').val(), 'foo bar');
-  assert.equal(this.$('input#title').is(":focus"), false);
+  assert.notEqual(document.activeElement.id, 'title');
 });

--- a/tests/integration/components/bookmark-form/component-test.js
+++ b/tests/integration/components/bookmark-form/component-test.js
@@ -1,0 +1,23 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('bookmark-form', 'Integration | Component | bookmark form', {
+  integration: true
+});
+
+test('it sets focus on the title field when empty', function(assert) {
+  this.set('bookmark', {title: null});
+  this.render(hbs`{{bookmark-form bookmark=bookmark}}`);
+
+  assert.equal(this.$('input#title').val(), '');
+  assert.equal(this.$('input#title').is(":focus"), true);
+});
+
+test('does not set focus on the title field when filled', function(assert) {
+  this.set('bookmark', {title: 'foo bar'});
+  this.render(hbs`{{bookmark-form bookmark=bookmark}}`);
+
+  assert.equal(this.get('bookmark.title'), 'foo bar');
+  assert.equal(this.$('input#title').val(), 'foo bar');
+  assert.equal(this.$('input#title').is(":focus"), false);
+});


### PR DESCRIPTION
I tried to start adding integration tests, starting with the bookmark form autofocus, after I just implemented that.

Unfortunately, I'm a bit stuck. When running `ember test --server`, the tests are green most of the time, but not always, in Chrome. But they always fail with PhantomJS. Must have something to do with either the focus pseudo attribute not being set at all when headless, or not fast enough. The latter would probably explain Chrome's random results.

@galfert Any idea if I'm doing it right, and/or how to make this work?

