### PR TITLE
Fix handling bookmarks without tags

### DIFF
--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -233,13 +233,10 @@ export default Service.extend(Evented, {
   },
 
   createTagListCache() {
-    let bookmarks = this.get('archiveBookmarks');
-    if (isEmpty(bookmarks)) { return; }
-
-    let tagList = bookmarks.mapBy('tags')
+    let tagList = this.get('archiveBookmarks').mapBy('tags')
                            .compact()
-                           .reduce((a, b) => a.concat(b))
-                           .reject((a) => Ember.isEmpty(a))
+                           .reduce((a, b) => a.concat(b), [''])
+                           .reject((a) => isEmpty(a))
                            .uniq()
                            .sort();
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,5 @@ dependencies:
     - npm config set spin false
     - npm install phantomjs-prebuilt
     - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+    - npm install -g bower
     - npm install

--- a/tests/unit/services/storage-test.js
+++ b/tests/unit/services/storage-test.js
@@ -39,8 +39,25 @@ test('#createTagListCache writes correct list to localStorage', function(assert)
   assert.equal(tags, 'app,no-backend,unhosted');
 });
 
-test('#createTagListCache writes empty list to localStorage when there are no tags', function(assert) {
+test('#createTagListCache writes empty list to localStorage when there are no bookmarks', function(assert) {
   let service = this.subject();
+
+  service.createTagListCache();
+
+  let tags = localStorage.getItem('webmarks:tags');
+  assert.equal(tags, '');
+});
+
+test('#createTagListCache writes empty list to localStorage when there are only bookmarks with no tags', function(assert) {
+  let service = this.subject();
+  let bookmarks = service.get('archiveBookmarks');
+
+  bookmarks.pushObject(Bookmark.create({
+    id: '1',
+    url: 'https://webmarks.5apps.com',
+    title: 'Webmarks',
+    tags: null
+  }));
 
   service.createTagListCache();
 


### PR DESCRIPTION
The recent commit 8c0f689 that was merged with PR #49 tried to fix an issues that I already fixed in master earlier, but wasn't in the PR's branch yet.

That new fix has some downsides compared to the original fix though.

1. It still fails when there are bookmarks but those don't have any tags.
2. When deleting the last bookmark, it would still keep the tags of that one in localStorage.

For 2. there was already a test that was now failing. For 1. I added a test in this PR.

I also added a `npm install -g bower` to the `circle.yml` as Circle was complaining about Bower not existing.