### PR TITLE
Optimize "back to list" behavior with back button

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -26,12 +26,6 @@ module.exports = {
       ]
     },
     {
-      "moduleId": "webmarks/components/bookmark-saved/template",
-      "only": [
-        "no-curly-component-invocation"
-      ]
-    },
-    {
       "moduleId": "webmarks/components/bookmark-search/template",
       "only": [
         "no-action",

--- a/app/components/bookmark-saved/template.hbs
+++ b/app/components/bookmark-saved/template.hbs
@@ -4,6 +4,10 @@
     <path class="checkmark__check" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8"/>
   </svg>
   <div class="controls">
-    {{#link-to "archive.index" class="button button-secondary"}}{{t "bookmark.saved.backToList"}}{{/link-to}}
+    <LinkTo @route="archive.index"
+            @replace={{true}}
+            class="button button-secondary">
+      {{t "bookmark.saved.backToList"}}
+    </LinkTo>
   </div>
 </section>


### PR DESCRIPTION
This changes the button so that it replaces the current route when clicking "back to list" after having added (or edited or deleted) a webmark.

This considerably improves the behavior when a user saves a webmark from the bookmarklet or the system's native share dialog (e.g. on Android). Currently, if they're going back to the list, and then decide to go back to the original page, they only go back to the add/edit form. With this
change, they go back immediately to the original page. Or, when using the system's share function, the entire overlay browser window will be closed.